### PR TITLE
Deduce the docker registry_url from repository

### DIFF
--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -60,6 +60,7 @@ attributes.default:
       persistence: ~
 
   docker:
+    registry_url: = get_docker_registry(@('docker.repository'))
     repository: = @("workspace.name")
     compose:
       file_version: '3'

--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -54,6 +54,14 @@ function('get_docker_external_networks'): |
   }
   = join(" ", $externalNetworks);
 
+function('get_docker_registry', [dockerRepository]): |
+  #!php
+  $dockerRepoParts = explode('/', $dockerRepository);
+  if (strpos($dockerRepoParts[0], '.') !== false) {
+      $registry = $dockerRepoParts[0];
+  }
+  = $registry ?? 'https://index.docker.io/v1/';
+
 function('branch'): |
   #!bash(workspace:/)
   =$(git branch | grep \* | cut -d ' ' -f2)

--- a/harness/config/pipeline.yml
+++ b/harness/config/pipeline.yml
@@ -11,9 +11,9 @@ command('app publish'):
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.repository')
+    echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.registry_url')
     run docker-compose push nginx
-    run docker logout @('docker.repository')
+    run docker logout @('docker.registry_url')
 
 command('app publish chart <release> <message>'):
   env:


### PR DESCRIPTION
Docker login doesn't work when the repository is using the default daemon registry (common when pushing to docker hub)

Also makes it clear there is no per-repository login credential store, only per-registry, so not good for parallel builds of different projects