### PR TITLE
Add ability to define env vars from k8s secrets

### DIFF
--- a/_twig/docker-compose.yml/application.yml.twig
+++ b/_twig/docker-compose.yml/application.yml.twig
@@ -39,9 +39,10 @@
     networks:
       - private
 {% endif %}
-    environment:
-{{ deep_merge_to_yaml([@('services.node.environment'), @('services.node.environment')], 2, 6) | raw }}
-
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.node.environment'),
+        @('services.node.environment_secrets')
+      ]), 2, 6) | raw }}
 
 {% if @('app.build') == 'static' %}
   nginx:
@@ -55,8 +56,10 @@
       - traefik.docker.network=my127ws
       - traefik.port=80
 {% if @('services.nginx.environment') %}
-    environment:
-{{ to_nice_yaml(@('services.nginx.environment'), 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.nginx.environment'),
+        @('services.nginx.environment_secrets')
+      ]), 2, 6) | raw }}
 {% endif %}
     networks:
       private:

--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -7,8 +7,6 @@ attributes:
         APP_HOST: = @('hostname')
     nginx:
       publish: true
-      ingress:
-        annotations: {}
       environment:
         APP_HOST: = @('hostname')
   pipeline:
@@ -17,6 +15,8 @@ attributes:
         podMonitoring: false
       services:
         nginx:
+          ingress:
+            annotations: {}
           metricsEnabled: false
           metricsEndpoints:
             - port: http

--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -1,13 +1,51 @@
-function('to_yaml', [text]): |
+function('to_yaml', [data]): |
   #!php
-  = preg_replace('/^/m', '  ', \Symfony\Component\Yaml\Yaml::dump($text, 100, 2));
+  $yaml = \Symfony\Component\Yaml\Yaml::dump($data, 100, 2));
+  if (is_array($data) && count($data) > 0) {
+    $yaml = "\n" . rtrim(preg_replace('/^/m', '  ', $yaml), "\n");
+  }
+  = $yaml;
 
-function('to_nice_yaml', [text, indentation, nesting]): |
+function('to_nice_yaml', [data, indentation, nesting]): |
   #!php
-  = preg_replace('/^/m', str_repeat(' ', $nesting ?: 2), \Symfony\Component\Yaml\Yaml::dump($text, 100, $indentation ?: 2));
+  $yaml = \Symfony\Component\Yaml\Yaml::dump($data, 100, $indentation ?: 2);
+  if (is_array($data) && count($data) > 0) {
+    $yaml = "\n" . rtrim(preg_replace('/^/m', str_repeat(' ', $nesting ?: 2), $yaml), "\n");
+  }
+  = $yaml;
+
+function('deep_merge', [arrays]): |
+  #!php
+  // source https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_array_merge_deep_array/7.x
+  $deepMerge = function ($arrays) use (&$deepMerge) {
+    $result = array();
+    foreach ($arrays as $array) {
+        if ($array === null) { continue; }
+        foreach ($array as $key => $value) {
+            // Renumber integer keys as array_merge_recursive() does. Note that PHP
+            // automatically converts array keys that are integer strings (e.g., '1')
+            // to integers.
+            if (is_integer($key)) {
+                $result[] = $value;
+            }
+            elseif (isset($result[$key]) && is_array($result[$key]) && is_array($value)) {
+                $result[$key] = $deepMerge(array(
+                    $result[$key],
+                    $value,
+                ));
+            }
+            else {
+                $result[$key] = $value;
+            }
+        }
+    }
+    return $result;
+  };
+  = $deepMerge($arrays);
 
 function('deep_merge_to_yaml', [arrays, indentation, nesting]): |
   #!php
+  trigger_error('deep_merge_to_yaml is deprecated, please use separate deep_merge and to_nice_yaml functions', E_USER_DEPRECATED);
   // source https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_array_merge_deep_array/7.x
   $deepMerge = function ($arrays) use (&$deepMerge) {
     $result = array();
@@ -46,6 +84,24 @@ function('publishable_services', [services]): |
     $services
   );
   = join(' ', array_filter($pushServices));
+
+function('filter_local_services', [services]): |
+  #!php
+  $filteredServices = [];
+  foreach ($services as $serviceName => $service) {
+    $filteredService = [];
+    foreach ($service as $key => $value) {
+      switch ($key) {
+        case 'environment':
+        case 'enabled':
+          $filteredService[$key] = $value;
+      }
+    }
+    if (count($filteredService) > 0) {
+      $filteredServices[$serviceName] = $filteredService;
+    }
+  }
+  = $filteredServices;
 
 function('get_docker_external_networks'): |
   #!php

--- a/harness/config/secrets.yml
+++ b/harness/config/secrets.yml
@@ -43,3 +43,50 @@ command('secret image-pull-config'):
       echo "If storing within workspace attributes, use `ws secret encrypt` first" >&2
       echo "${DOCKER_CONFIG}" | base64
     fi
+
+command('sealed-secret encrypt (string|blob) <secret-name>'):
+  env:
+    INPUT_TYPE: = input.command(3)
+    SEALED_SECRETS_CONTROLLER_NAME: = @('helm.sealed_secrets.controller_name')
+    SEALED_SECRETS_CONTROLLER_NAMESPACE: = @('helm.sealed_secrets.controller_namespace')
+    SECRET_NAME: = input.argument('secret-name')
+  exec: |
+    #!bash
+    if ! command -v kubeseal >/dev/null; then
+      echo 'kubeseal is needed in order to use this command' >&2
+      exit 1
+    fi
+    echo "Enter the secret ${INPUT_TYPE} to encrypt" >&2
+    case "${INPUT_TYPE}" in
+      string)
+        read DATA # read a single line
+        ;;
+      blob)
+        if [ -t 1 ] ; then
+          # Use an editor with a temp file to allow longer terminal input
+          TMPFILE="$(mktemp -t tmp.XXXXXXXXX)"
+          "${EDITOR:-vi}" "${TMPFILE}"
+          DATA="$(cat "${TMPFILE}")"
+          rm -f "${TMPFILE}"
+        else
+          # read from stdin until EOF
+          DATA="$(cat)"
+        fi
+        ;;
+    esac
+    echo 'Encrypting as a sealed-secret value with certificate from current kubectl context' >&2
+    KUBESEAL_OPTS=(
+      --name "${SECRET_NAME}"
+      --scope cluster-wide 
+    )
+    if [ -n "${SEALED_SECRETS_CONTROLLER_NAME:-}" ]; then
+      KUBESEAL_OPTS+=(
+        --controller-name "${SEALED_SECRETS_CONTROLLER_NAME}"
+      )
+    fi
+    if [ -n "${SEALED_SECRETS_CONTROLLER_NAMESPACE:-}" ]; then
+      KUBESEAL_OPTS+=(
+        --controller-namespace "${SEALED_SECRETS_CONTROLLER_NAMESPACE}"
+      )
+    fi
+    echo "${DATA}" | kubeseal --raw "${KUBESEAL_OPTS[@]}"

--- a/helm/app/templates/_helper.tpl
+++ b/helm/app/templates/_helper.tpl
@@ -1,0 +1,23 @@
+{{- define "service.environment.secret" }}
+{{ if .service.environment_secrets }}
+{{ if .Values.feature.sealed_secrets }}
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+{{ else }}
+apiVersion: v1
+kind: Secret
+{{ end }}
+metadata:
+  name: {{ .Values.resourcePrefix }}{{ .service_name }}
+{{ if .Values.feature.sealed_secrets }}
+  annotations:
+    sealedsecrets.bitnami.com/cluster-wide: "true"
+spec:
+  encryptedData:
+{{ index .service.environment_secrets | toYaml | nindent 4 -}}
+{{ else }}
+stringData:
+{{ index .service.environment_secrets | toYaml | nindent 2 -}}
+{{ end }}
+{{ end }}
+{{- end }}

--- a/helm/app/templates/application/nginx/deployment.yaml
+++ b/helm/app/templates/application/nginx/deployment.yaml
@@ -29,6 +29,11 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
+        {{- if .Values.services.nginx.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}nginx
+        {{- end }}
         image: {{ .Values.docker.image.nginx }}
         imagePullPolicy: Always
         ports:

--- a/helm/app/templates/application/nginx/secret.yaml
+++ b/helm/app/templates/application/nginx/secret.yaml
@@ -1,0 +1,1 @@
+{{ template "service.environment.secret" (dict "service_name" "nginx" "service" .Values.services.nginx "Values" .Values) }}

--- a/helm/app/values-preview.yaml.twig
+++ b/helm/app/values-preview.yaml.twig
@@ -1,13 +1,10 @@
 {% if @('pipeline.preview.services') %}
-services:
-{{ to_nice_yaml(@('pipeline.preview.services'), 2, 2) | raw }}  
+services: {{ to_nice_yaml(@('pipeline.preview.services'), 2, 2) | raw }}  
 {% endif %}
 {% if @('pipeline.preview.persistence') %}
-persistence:
-{{ to_nice_yaml(@('pipeline.preview.persistence'), 2, 2) | raw }}
+persistence: {{ to_nice_yaml(@('pipeline.preview.persistence'), 2, 2) | raw }}
 {% endif %}
 
 {% if @('pipeline.preview.resources') %}
-resources:
-{{ to_nice_yaml(@('pipeline.preview.resources'), 2, 2) | raw }}
+resources: {{ to_nice_yaml(@('pipeline.preview.resources'), 2, 2) | raw }}
 {% endif %}

--- a/helm/app/values-production.yaml.twig
+++ b/helm/app/values-production.yaml.twig
@@ -1,10 +1,8 @@
 
 {% if @('pipeline.production.services') %}
-services:
-{{ to_nice_yaml(@('pipeline.production.services'), 2, 2) | raw }}  
+services: {{ to_nice_yaml(@('pipeline.production.services'), 2, 2) | raw }}  
 {% endif %}
 
  {% if @('pipeline.production.resources') %}
-resources:
-{{ to_nice_yaml(@('pipeline.production.resources'), 2, 2) | raw }}
+resources: {{ to_nice_yaml(@('pipeline.production.resources'), 2, 2) | raw }}
 {% endif %}

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -1,23 +1,20 @@
-feature:
-{{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
+feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 
 docker:
   image_pull_config: {{ @('docker.image_pull_config') | raw }}
   image:
     nginx: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx' }}
 
-services:
-{{ deep_merge_to_yaml([@('services'), @('pipeline.base.services')], 2, 2) | raw }}
+services: {{ to_nice_yaml(deep_merge([
+    filter_local_services(@('services')),
+    @('pipeline.base.services')
+  ]), 2, 2) | raw }}
 
-resources:
-{{ to_nice_yaml(@('resources'), 2, 2) | raw }}
+resources: {{ to_nice_yaml(@('resources'), 2, 2) | raw }}
 
-prometheus:
-{{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
+prometheus: {{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
 
 resourcePrefix: {{ @('pipeline.base.resourcePrefix') | json_encode | raw }}
 
-ingress:
-{{ to_nice_yaml(@('pipeline.base.ingress'), 2, 2) | raw }}
-istio:
-{{ to_nice_yaml(@('pipeline.base.istio'), 2, 2) | raw }}
+ingress: {{ to_nice_yaml(@('pipeline.base.ingress'), 2, 2) | raw }}
+istio: {{ to_nice_yaml(@('pipeline.base.istio'), 2, 2) | raw }}

--- a/helm/qa/values.yaml.twig
+++ b/helm/qa/values.yaml.twig
@@ -1,10 +1,8 @@
 {{ @('workspace.name') }}:
   resourcePrefix: {{ @('pipeline.qa.resourcePrefix') | json_encode | raw }}
 {% if @('pipeline.qa.services') %}
-  services:
-{{ to_nice_yaml(@('pipeline.qa.services'), 2, 4) | raw }}  
+  services: {{ to_nice_yaml(@('pipeline.qa.services'), 2, 4) | raw }}  
 {% endif %}
 {% if @('pipeline.qa.persistence') %}
-  persistence:
-{{ to_nice_yaml(@('pipeline.qa.persistence'), 2, 4) | raw }}
+  persistence: {{ to_nice_yaml(@('pipeline.qa.persistence'), 2, 4) | raw }}
 {% endif %}


### PR DESCRIPTION
* with sealed-secrets used by default for encryption
* environment variables in templates simplified by merging dicts before iterating
* support for custom CRD schemas necessary to pass tests
* local secrets (plaintext still) excluded from pipeline to avoid confusion over encryption