### PR TITLE
Update k8s Ingress to v1 and add optional ingressClassName

### DIFF
--- a/helm/app/templates/application/nginx/ingress.yaml
+++ b/helm/app/templates/application/nginx/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if eq .Values.ingress.type "standard" }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- if .Values.services.nginx.ingress.annotations }}
@@ -13,13 +13,18 @@ metadata:
     app.service: {{ .Values.resourcePrefix }}nginx
   name: {{ .Values.resourcePrefix }}nginx
 spec:
+  {{- with (pick .Values.services.nginx.ingress "ingressClassName" "tls") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   rules:
   - host: {{ index .Values.services "nginx" "environment" "APP_HOST" }}
     http:
       paths:
       - backend:
-          serviceName: {{ .Values.resourcePrefix }}nginx
-          servicePort: 80
+          service:
+            name: {{ .Values.resourcePrefix }}nginx
+            port:
+              number: 80
 status:
   loadBalancer: {}
 {{ end }}


### PR DESCRIPTION
Needed for k8s 1.22, supported since 1.19, and requires ArgoCD > 1.8