### PR TITLE
Use explicit / prefix for Ingress path

### DIFF
--- a/helm/app/templates/application/nginx/ingress.yaml
+++ b/helm/app/templates/application/nginx/ingress.yaml
@@ -20,7 +20,9 @@ spec:
   - host: {{ index .Values.services "nginx" "environment" "APP_HOST" }}
     http:
       paths:
-      - backend:
+      - path: /
+        pathType: Prefix
+        backend:
           service:
             name: {{ .Values.resourcePrefix }}nginx
             port:


### PR DESCRIPTION
Since pathType: ImplementationSpecific is the only type supporting not specifying path:, yet it could be ... implementation specific