### PR TITLE
Disable nginx server_tokens by default

### DIFF
--- a/harness/attributes/common-spa.yml
+++ b/harness/attributes/common-spa.yml
@@ -13,5 +13,14 @@ attributes.default:
       steps:
         - yarn dev
 
+  nginx:
+    # used to set site specific configurations under server directive
+    site:
+      conf: []
+    # used to set nginx global configurations under http directive
+    global:
+      conf:
+        server_tokens: 'off'
+
   node:
     version: 16


### PR DESCRIPTION
The nginx config was also inadvertently deleted as well, however rendered the same