### PR TITLE
Fix dynamic mode's tini command change

### DIFF
--- a/docker/image/app/root-node/entrypoint.sh
+++ b/docker/image/app/root-node/entrypoint.sh
@@ -22,5 +22,5 @@ bootstrap
 if [ "${1:-}" == "sleep" ]; then
     "$@"
 else
-    exec /sbin/docker-init su -- node -c "$(printf "%q " "${@:1}")"
+    exec /sbin/tini su -- node -c "$(printf "%q " "${@:1}")"
 fi


### PR DESCRIPTION
Due to using console image as parent, it changed to tini